### PR TITLE
Added getRelativeTime method(s)

### DIFF
--- a/app/services/common.js
+++ b/app/services/common.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require('fs'),
+      tzwhere = require('tzwhere'),
       pokemonDataJson = __appbase + '../resources/json/pokemonGoData.json';
 
 module.exports = {
@@ -62,5 +63,23 @@ module.exports = {
             pokemonNameArray.push(jsonDataArray[i].Name.toLowerCase())
         }
         return pokemonNameArray;
+    },
+    /*
+     * takes arbitrary date and coordinates
+     * and returns local time at this place as a String in "HH:MM:SS" format
+     */
+    getRelativeTime : function (date, lat, lng) {
+        tzwhere.init(); //takes 5 seconds to initialize (because of comlex timezone shapes and so on)
+        var d = new Date(date.getTime() + tzwhere.tzOffsetAt(lat,lng));
+        return d.toUTCString().split(' ')[4];
+    },
+    /*
+     * same as getRelativeTime but faster and sometimes not correct
+     * since it implies linear timezones every 15° longitude
+     */
+    getRelativeTimeFast : function (date, lat, lng) {
+        var offset = Math.sign(lng) * Math.ceil((Math.abs(lng) - 7.5)/15);
+        var d = new Date(date.getTime() + offset * 3600000);
+        return d.toUTCString().split(' ')[4];
     }
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "path": "^0.12.7",
     "request": "^2.74.0",
     "stream": "0.0.2",
-    "twitter-stream-api": "^0.4.3"
+    "twitter-stream-api": "^0.4.3",
+    "tzwhere": "1.0.0"
   }
 }


### PR DESCRIPTION
Implemented method(s) to get the local (relative) time based on a date and a location. This will be used for the Machine Learning as discussed in #2 

One method uses the "tzwhere" library and has to be initialized first (tzwhere.init()) to load up some complex shape files for the timezones. On my system this takes about 5 seconds and it would be unfortunate if we call that everytime we want to look up a local time.
Because of this i also implemented a "quick and dirty" approach which assumes a new timezone every 15° of longitude.
