### PR TITLE
#87 - Fix for docker build failure

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,11 +21,12 @@ module.exports = function (grunt) {
         }
     });
 
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-contrib-nodeunit');
-    grunt.loadNpmTasks('grunt-contrib-clean');
+    // grunt.loadNpmTasks('grunt-contrib-jshint');
+    // grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    // grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-apidoc');
 
-    grunt.registerTask('test', ['jshint', 'nodeunit']);
-    grunt.registerTask('default', ['clean', 'apidoc']);
+    // grunt.registerTask('test', ['jshint', 'nodeunit']);
+    // grunt.registerTask('default', ['clean', 'apidoc']);
+    grunt.registerTask('default', ['apidoc']);
 };


### PR DESCRIPTION
Commented the unused tasks for the moment. They can be uncommented once we start using them.
The docker build is failing due to warnings caused by these dependencies.
