### PR TITLE
Removed tzwhere and every dependency. Switched to "fast" method.

### DIFF
--- a/app/services/common.js
+++ b/app/services/common.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const fs = require('fs'),
-      tzwhere = require('tzwhere'),
       pokemonDataJson = __appbase + '../resources/json/pokemonGoData.json';
 
 module.exports = {
@@ -50,17 +49,9 @@ module.exports = {
     /*
      * takes arbitrary date and coordinates
      * and returns local time at this place as a String in "HH:MM:SS" format
+     * just approximates timezone, assumes new timezone every 15° lng
      */
     getRelativeTime : function (date, lat, lng) {
-        tzwhere.init(); //takes 5 seconds to initialize (because of comlex timezone shapes and so on)
-        var d = new Date(date.getTime() + tzwhere.tzOffsetAt(lat,lng));
-        return d.toUTCString().split(' ')[4];
-    },
-    /*
-     * same as getRelativeTime but faster and sometimes not correct
-     * since it implies linear timezones every 15° longitude
-     */
-    getRelativeTimeFast : function (date, lat, lng) {
         var offset = Math.sign(lng) * Math.ceil((Math.abs(lng) - 7.5)/15);
         var d = new Date(date.getTime() + offset * 3600000);
         return d.toUTCString().split(' ')[4];

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "request": "^2.74.0",
     "stream": "0.0.2",
     "twitter-stream-api": "^0.4.3",
-    "tzwhere": "1.0.0",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Removed tzwhere (library for timezones) and every dependency, because it is possible reason for build failure of the docker. Switched to "fast" method.
