### PR TITLE
Allow environment variables for db config parameters

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,10 @@
 module.exports = {
     "database" : {
-        "username": "",
-        "password": "",
-        "port": "27017",
-        "uri": "localhost",
-        "collection": "PokeData"
+        "username": process.env.DB_USERNAME || "",
+        "password": process.env.DB_PASSWORD || "",
+        "port": process.env.DB_PORT || "27017",
+        "uri": process.env.DB_URI || "localhost",
+        "collection": process.env.DB_COLLECTION || "PokeData"
     },
     "shared_database": {
         "username": process.env.MLAB_USERNAME,


### PR DESCRIPTION
Hi PokeData team,
I'm member of team E and I'm currently in the process of integrating the other projects. For that purpose we will use Docker and as I have already noticed you guys are using Docker as well (which makes things easier for me, so thanks a lot!). 
We would like to connect the PokeData Docker container to a MongoDB container. This implies that your backend won't be able to reach the MongoDB-instance at `localhost` anymore (as they live in different containers). The easiest way of working around that issue would be to use environment variables for database parameters (host, user, password and collection) and specify them in the docker-compose file. You are already using environment variables in your `config.js` so I just added them to the `config["database"]` object as well. 
