### PR TITLE
removed save null location from data retrieved from twitter

### DIFF
--- a/app/stores/twitter.js
+++ b/app/stores/twitter.js
@@ -51,13 +51,7 @@ module.exports = {
 
                             location = {type: "Point",coordinates: [pokemonFoundLongitude, pokemonFoundLatitude]};
                             savePokemonSighthing(pokemonSighting);
-                        } else {
-                            // save null location when link is not google maps related
-                            savePokemonSighthing(pokemonSighting);
                         }
-                    } else {
-                        // save null location when response is not 200
-                        savePokemonSighthing(pokemonSighting);
                     }
                 });
         }


### PR DESCRIPTION
- removed other places to save location as null when the twitter link is not a google maps url
