### PR TITLE
Updated to hashPokemonGo 0.9.0 ; Fixes HashMap import (is now lower case)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "express": "^4.14.0",
     "fs": "0.0.1-security",
     "grunt-apidoc": "^0.11.0",
-    "hashpokemongo": "^0.8.5",
+    "hashpokemongo": "^0.9.0",
     "https": "^1.0.0",
     "jsonfile": "^2.3.1",
     "moment": "^2.14.1",


### PR DESCRIPTION
Relates to #162 and #167 
