### PR TITLE
Token impl

### DIFF
--- a/app/api/sighting.js
+++ b/app/api/sighting.js
@@ -179,7 +179,7 @@ module.exports = {
     getByTimeRange: function (req, res) {
         logger.info('Get Pokemon Sightings within a specific time range');
 
-        sighting.getByTimeRange(req.params, function(success, limited, message) {
+        sighting.getByTimeRange(req, function(success, limited, message) {
             if(success === 1)
                 res.status(200).json({message: 'Success', limited: limited, data: message});
             else

--- a/app/stores/sighting.js
+++ b/app/stores/sighting.js
@@ -32,7 +32,7 @@ module.exports = {
     /*
      * fetching the particular pokemon details
      */
-    get: function (data, callback) {
+    get: function (data, callback, token) {
         Sighting.find(data, function (err, obj) {
             if (!obj || err) {// already existing data and return 0 for indicating
                 let error = err && err.message;
@@ -44,7 +44,7 @@ module.exports = {
                     callback(1, false, obj);
                 }
             }
-        }).sort({"appearedOn": -1}).limit(config.limit + 1);
+        }).sort({"appearedOn": -1}).limit(token === config.token ? 0 : config.limit + 1);
     },
 
     /*
@@ -109,11 +109,11 @@ module.exports = {
      * get the pokemon sightings within a specific time range
      */
     getByTimeRange : function (req, callback) {
-        let range = (req.range) || '1d',
+        let range = (req.params.range) || '1d',
             fromTs,
             toTs;
 
-        fromTs = new Date(req.ts) || new Date();
+        fromTs = new Date(req.params.ts) || new Date();
 
         let rangeValue = parseInt(range, 10),
             rangeSpan = range.replace(/\d+/g, '');
@@ -144,7 +144,7 @@ module.exports = {
             $lte: toTs.toUTCString()
         }}, function (status, limited, response) {
             callback(status, limited, response);
-        });
+        }, req.query.token);
     },
     /*
      * get the pokemon sightings matching the specified search parameters

--- a/config.js
+++ b/config.js
@@ -48,6 +48,7 @@ module.exports = {
     },
     "pokemonSpawnTime" : 900000 ,// 15 minutes in milliseconds,
     "limit" : 1000,
+    "token" : "hastobefilledwithsupersecrettoken", //please choose secret token and communicate it privately
     "server": {
         "port": "8080"
     },

--- a/config.js
+++ b/config.js
@@ -48,7 +48,7 @@ module.exports = {
     },
     "pokemonSpawnTime" : 900000 ,// 15 minutes in milliseconds,
     "limit" : 1000,
-    "token" : process.env.API_TOKEN, //please choose secret token and communicate it privately
+    "token" : process.env.API_TOKEN || "I0TPIIpCLH8lR8iDrCMV", //please choose secret token and communicate it privately
     "server": {
         "port": "8080"
     },

--- a/config.js
+++ b/config.js
@@ -48,7 +48,7 @@ module.exports = {
     },
     "pokemonSpawnTime" : 900000 ,// 15 minutes in milliseconds,
     "limit" : 1000,
-    "token" : "hastobefilledwithsupersecrettoken", //please choose secret token and communicate it privately
+    "token" : process.env.API_TOKEN, //please choose secret token and communicate it privately
     "server": {
         "port": "8080"
     },


### PR DESCRIPTION
query parameter has to be named "token" like so:
`/api/pokemon/sighting/ts/2016-09-14T08:00:00.000Z/range/1h?token=supersecret`.
It works only for this route `/api/pokemon/sighting/ts/`.

I tested locally with my DB but depending on the data density you might crash the server because the node process is running out of memory when sending too large json. For the range of 1d it did crash, for 1h it was like taking pretty long and for 10m it was working.

Please use https so the token won't be sent over the wire in plaintext.
Also make sure to choose a secret token and communicate it privately @sacdallago @bensLine 
It has to be entered in `config.js` @sacdallago 